### PR TITLE
add support for agents PLAN.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Planning
+
+Repository-specific plan guidance lives in [docs/plans/README.md](/Users/okhomchenko/src/python/atomicl/docs/plans/README.md).
+
+- Track work in `docs/plans/<feature>/PLAN.md`.
+- Use a stable human-readable slug for `<feature>` by default.
+- If the human explicitly mentions a ticket or requests ticket-based naming, include the ticket in the directory name.
+- Treat `docs/plans/<feature>/PLAN.md` as the only live planning document for that work.
+- Update `Tasks` and `Notes / Findings` in place while executing.
+- Do not change `Goal` or `Exit Criteria` without human approval.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,68 @@
+# Planning Layout
+
+This repository tracks work in a single live document per feature:
+
+`/docs/plans/<feature>/PLAN.md`
+
+That `PLAN.md` is both the design record and the execution board. Supporting files are allowed, but this is the only live execution tracker for the work.
+
+## Feature Directory Naming
+
+Use a stable human-readable slug for `<feature>` by default:
+
+- `/docs/plans/overflow-semantics/PLAN.md`
+- `/docs/plans/cpython-build-cleanup/PLAN.md`
+
+If the human explicitly mentions a ticket or wants ticket-based naming, include it in the directory name:
+
+- `/docs/plans/123-overflow-semantics/PLAN.md`
+
+## Plan Ownership
+
+Each feature `PLAN.md` is a live document.
+
+- Agents should update `Tasks` and `Notes / Findings` while executing work.
+- `Goal` and `Exit Criteria` are human-owned sections.
+- Agents must not rewrite `Goal` or `Exit Criteria` without human approval.
+
+## Default `PLAN.md` Shape
+
+Use this structure unless the human asks for something else:
+
+```md
+# <Plan title>
+
+Status: proposed | in_progress | done
+
+## Goal
+
+What should exist when this work is complete.
+
+## Exit Criteria
+
+- Observable condition that proves the work is complete
+- Observable condition that proves the work is complete
+
+## Context
+
+Relevant background, constraints, and links.
+
+## Tasks
+
+- [ ] Concrete task
+- [ ] Concrete task
+
+## Notes / Findings
+
+- Decision, discovery, blocker, or follow-up worth preserving during execution.
+```
+
+## Extra Files
+
+Add extra files next to a feature `PLAN.md` only when the work actually needs them, for example:
+
+- `research.md`
+- `notes.md`
+- `decisions.md`
+
+Those files support the feature plan, but `docs/plans/<feature>/PLAN.md` remains the only live tracking document.


### PR DESCRIPTION
## Summary

- document the repository convention for a single live feature plan at `docs/plans/<feature>/PLAN.md`
- add a repo-local `AGENTS.md` that points agents at that planning structure without repeating global guidance
- define that `Goal` and `Exit Criteria` are human-owned sections and that ticket-prefixed plan names are only used when the human explicitly asks for them

## Why

This change establishes how planning documents are organized in this repository so feature work is tracked in one place and future agents follow the same structure.

## Validation

- inspected the planning docs locally
- verified the documented `PLAN.md` order is `Goal`, then `Exit Criteria`
- verified the repo-local `AGENTS.md` is planning-only and references `docs/plans/<feature>/PLAN.md`
