### PR TITLE
Fix AGENTS path guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Planning
 
-Repository-specific plan guidance lives in [docs/plans/README.md](/Users/okhomchenko/src/python/atomicl/docs/plans/README.md).
+Repository-specific plan guidance lives in [docs/plans/README.md](docs/plans/README.md).
 
 - Track work in `docs/plans/<feature>/PLAN.md`.
 - Use a stable human-readable slug for `<feature>` by default.
@@ -13,3 +13,7 @@ Repository-specific plan guidance lives in [docs/plans/README.md](/Users/okhomch
 - In each atomic implementation commit, update `docs/plans/<feature>/PLAN.md` so it is clear which task or finding that commit completed.
 - Update `Tasks` and `Notes / Findings` in place while executing.
 - Do not change `Goal` or `Exit Criteria` without human approval.
+
+## Working On Code
+
+- Do not include machine-specific absolute filesystem paths in checked-in files; prefer repository-relative paths and links when applicable.


### PR DESCRIPTION
## Why

`AGENTS.md` pointed `docs/plans/README.md` at a machine-specific absolute path from one local checkout. That made the guidance non-portable and left the broader rule about checked-in paths in the wrong section.

## What Changed

- replaced the absolute `docs/plans/README.md` link in `AGENTS.md` with a repository-relative link
- added a general `## Working On Code` section in `AGENTS.md`
- moved the rule about machine-specific absolute filesystem paths into that general section so it applies to checked-in files broadly rather than reading like planning-only guidance

## Impact

The repository guidance is now portable across checkouts, and the absolute-path rule is documented at the right level for docs, tests, and other checked-in files.