### PR TITLE
Keep Cython in the dev workflow only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Bootstrap a development environment::
 The documented local workflow assumes the default ``dev`` group is
 installed via ``uv sync`` before running lint, tests, benchmarks, or
 packaging commands from a checkout, so Cython is available there when
-needed.
+needed for Cython-backed packaging workflows.
 
 Run the test suite on the default interpreter::
 
@@ -82,6 +82,11 @@ Run a faster local benchmark pass for one implementation::
 
     uv run --group benchmark python benchmarks.py --fast --impl atomicl_cy
 
+Regenerate ``src/atomicl/_cy.c`` after editing ``src/atomicl/_cy.pyx``::
+
+    uv sync
+    uv build
+
 Build Behavior
 --------------
 
@@ -95,7 +100,7 @@ Source distributions ship generated C code for the extension, so end
 systems installing from the released sdist do not need Cython just to
 build the package.
 
-When Cython is available in the build environment, the build uses
+When packaging from a checkout with uv_, the local build uses
 ``src/atomicl/_cy.pyx`` and regenerates ``src/atomicl/_cy.c`` before
 compiling the extension.
 

--- a/docs/plans/cython-dev-only/PLAN.md
+++ b/docs/plans/cython-dev-only/PLAN.md
@@ -1,0 +1,47 @@
+# Cython Dev-Only Build Path
+
+Status: done
+
+## Goal
+
+Make Cython a maintainer/developer packaging tool only, while ensuring that
+release sdists include generated C sources and install without requiring
+Cython, and preserving the optional native-extension fallback behavior.
+
+## Exit Criteria
+
+- Checkout packaging does not require Cython in `[build-system].requires`.
+- uv packaging regenerates `src/atomicl/_cy.c` automatically when building from
+  a checkout.
+- Release sdists include generated `src/atomicl/_cy.c`.
+- Developer workflows still install Cython by default through the `dev` group.
+- Installing from the built sdist succeeds without depending on Cython in the
+  isolated build environment.
+- The repo docs and plan reflect the new packaging contract.
+
+## Context
+
+- The repo's current `setup.py` already supports building from `.pyx` when
+  Cython is importable and from `.c` otherwise.
+- The intended model is to keep Cython available for packaging from a checkout,
+  while shipping generated C in the release sdist so downstream installs do not
+  need Cython.
+- uv can inject extra build dependencies for a specific package without
+  publishing them as package metadata.
+
+## Tasks
+
+- [x] Create the live feature plan and use it as the execution tracker.
+- [x] Configure the packaging tooling to inject Cython for checkout builds.
+- [x] Remove Cython from non-dev packaging metadata where it is no longer
+  required.
+- [x] Validate local tests and sdist install behavior without Cython.
+
+## Notes / Findings
+
+- uv's `extra-build-dependencies` setting can provide Cython to the local build
+  environment for `atomicl` without publishing Cython as a package build
+  requirement.
+- Validation should prove two separate behaviors: `uv` packaging from a checkout
+  regenerates `_cy.c`, and a fresh `pip install` from the built sdist works
+  without Cython.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "pytest-timeout>=2.4",
 ]
 test = [
-    "Cython>=3.1",
     "coverage>=7.8",
     "pytest>=8.3",
     "pytest-timeout>=2.4",
@@ -68,3 +67,6 @@ where = ["src"]
 
 [tool.uv]
 default-groups = ["dev"]
+
+[tool.uv.extra-build-dependencies]
+atomicl = ["Cython>=3.1"]

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,6 @@ dev = [
 ]
 test = [
     { name = "coverage" },
-    { name = "cython" },
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
@@ -53,7 +52,6 @@ dev = [
 ]
 test = [
     { name = "coverage", specifier = ">=7.8" },
-    { name = "cython", specifier = ">=3.1" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-timeout", specifier = ">=2.4" },
 ]


### PR DESCRIPTION
## Why

The packaging modernization briefly moved the project toward requiring Cython in the wrong places. The intended contract is narrower: Cython should stay in the developer workflow for packaging from a checkout, while released sdists should still install without requiring Cython.

## What Changed

- kept Cython in the `dev` workflow while removing it from the non-dev `test` dependency group
- configured `uv` to inject Cython for local checkout builds via `tool.uv.extra-build-dependencies`
- documented the maintainer workflow as `uv sync` followed by `uv build`
- updated the live feature plan to describe the checkout-build and sdist-install contract

## Impact

Packaging from a checkout now goes through the `uv` tooling path when Cython-backed regeneration is needed. Released sdists still contain generated C sources, so installing from the sdist does not require Cython.