### PR TITLE
Migrate lint workflow from Flake8 to Ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Run flake8
-        run: uv run flake8
+      - name: Run ruff check
+        run: uv run ruff check
+
+      - name: Run ruff format check
+        run: uv run ruff format --check
 
   tests:
     runs-on: ubuntu-latest

--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,17 @@ Run the test suite on the default interpreter::
 
     uv run pytest
 
-Run lint::
+Check lint::
 
-    uv run flake8
+    uv run ruff check
+
+Apply lint fixes and import sorting::
+
+    uv run ruff check --fix
+
+Format code::
+
+    uv run ruff format
 
 Run the test suite on a specific supported interpreter::
 

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -6,24 +6,23 @@ import pyperf as perf
 import atomicl._cy
 import atomicl._py
 
-
 IMPLEMENTATIONS = {
-    'atomic': atomic.AtomicLong,
-    'atomicl_py': atomicl._py.AtomicLong,
-    'atomicl_cy': atomicl._cy.AtomicLong
+    "atomic": atomic.AtomicLong,
+    "atomicl_py": atomicl._py.AtomicLong,
+    "atomicl_cy": atomicl._cy.AtomicLong,
 }
 
 
 def benchmark_name(name, ctx, prefix=None, use_prefix=False):
     if use_prefix:
-        return '%s%s' % (prefix % ctx, name)
+        return "%s%s" % (prefix % ctx, name)
 
     return name
 
 
 def add_cmdline_args(cmd, args):
     if args.impl:
-        cmd.extend(['--impl', args.impl])
+        cmd.extend(["--impl", args.impl])
 
 
 def ctor_default(loops, cls):
@@ -141,37 +140,31 @@ def cas(loops, counter, first, second):
     return perf.perf_counter() - t0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = perf.Runner(add_cmdline_args=add_cmdline_args)
 
     parser = runner.argparser
-    parser.add_argument('--impl', choices=sorted(IMPLEMENTATIONS),
-                        help='specific implementation to benchmark')
+    parser.add_argument(
+        "--impl",
+        choices=sorted(IMPLEMENTATIONS),
+        help="specific implementation to benchmark",
+    )
 
     options = parser.parse_args()
     implementations = (options.impl,) if options.impl else IMPLEMENTATIONS
 
     for impl in implementations:
         impl = IMPLEMENTATIONS[impl]
-        name = functools.partial(benchmark_name, ctx=dict(impl=impl),
-                                 prefix='(impl = %(impl)s) ',
-                                 use_prefix=len(implementations) > 1)
+        name = functools.partial(
+            benchmark_name,
+            ctx=dict(impl=impl),
+            prefix="(impl = %(impl)s) ",
+            use_prefix=len(implementations) > 1,
+        )
 
-        runner.bench_time_func(name('ctor_default'),
-                               ctor_default, impl,
-                               inner_loops=10)
-        runner.bench_time_func(name('ctor'),
-                               ctor, impl,
-                               inner_loops=10)
-        runner.bench_time_func(name('increment'),
-                               inc, impl(),
-                               inner_loops=10)
-        runner.bench_time_func(name('decrement'),
-                               dec, impl(),
-                               inner_loops=10)
-        runner.bench_time_func(name('setter'),
-                               setter, impl(),
-                               inner_loops=10)
-        runner.bench_time_func(name('cas'),
-                               cas, impl(0), 0, 42,
-                               inner_loops=10)
+        runner.bench_time_func(name("ctor_default"), ctor_default, impl, inner_loops=10)
+        runner.bench_time_func(name("ctor"), ctor, impl, inner_loops=10)
+        runner.bench_time_func(name("increment"), inc, impl(), inner_loops=10)
+        runner.bench_time_func(name("decrement"), dec, impl(), inner_loops=10)
+        runner.bench_time_func(name("setter"), setter, impl(), inner_loops=10)
+        runner.bench_time_func(name("cas"), cas, impl(0), 0, 42, inner_loops=10)

--- a/docs/plans/ruff-migration/PLAN.md
+++ b/docs/plans/ruff-migration/PLAN.md
@@ -33,8 +33,8 @@ keeping the package runtime behavior and public API unchanged.
 ## Tasks
 
 - [x] Create the live feature plan and use it as the execution tracker.
-- [ ] Replace Flake8 with Ruff in development dependencies and configuration.
-- [ ] Update the local workflow and CI documentation to use Ruff.
+- [x] Replace Flake8 with Ruff in development dependencies and configuration.
+- [x] Update the local workflow and CI documentation to use Ruff.
 - [ ] Apply Ruff fixes, import sorting, and formatting to tracked Python files.
 - [ ] Validate Ruff, tests, and build commands from the migrated workflow.
 
@@ -46,3 +46,5 @@ keeping the package runtime behavior and public API unchanged.
   setting an explicit line length.
 - `ruff check` and `ruff format --check` are both required in CI because the
   formatter does not subsume linting.
+- The repo can rely on Ruff's default current-directory discovery, so the
+  documented commands omit an explicit `.` path.

--- a/docs/plans/ruff-migration/PLAN.md
+++ b/docs/plans/ruff-migration/PLAN.md
@@ -1,0 +1,48 @@
+# Ruff Migration
+
+Status: in_progress
+
+## Goal
+
+Replace Flake8 with Ruff for linting, formatting, and import sorting while
+keeping the package runtime behavior and public API unchanged.
+
+## Exit Criteria
+
+- The development dependency set uses `ruff` instead of `flake8`.
+- `pyproject.toml` contains the Ruff configuration needed for linting and
+  import sorting.
+- The README documents `uv run ruff check`, `uv run ruff check --fix`, and
+  `uv run ruff format`.
+- GitHub Actions runs `uv run ruff check` and `uv run ruff format --check`.
+- Tracked Python files are Ruff-clean and Ruff-formatted.
+- `uv run ruff check`, `uv run ruff format --check`, `uv run pytest`, and
+  `uv build` all pass from a clean checkout.
+
+## Context
+
+- The repo currently documents and enforces `uv run flake8` locally and in CI.
+- The project already declares `requires-python = ">=3.11,<3.15"`, so Ruff can
+  infer the minimum supported Python version without an explicit
+  `target-version`.
+- The migration should follow Ruff defaults where practical, while enabling
+  import sorting via the `I` rule family.
+- Historical plan documents remain unchanged; this file is the only live
+  tracker for the migration work.
+
+## Tasks
+
+- [x] Create the live feature plan and use it as the execution tracker.
+- [ ] Replace Flake8 with Ruff in development dependencies and configuration.
+- [ ] Update the local workflow and CI documentation to use Ruff.
+- [ ] Apply Ruff fixes, import sorting, and formatting to tracked Python files.
+- [ ] Validate Ruff, tests, and build commands from the migrated workflow.
+
+## Notes / Findings
+
+- Baseline validation before migration passed with `uv run flake8` and
+  `uv run pytest` (79 tests).
+- Ruff defaults to `line-length = 88`, which the migration keeps by not
+  setting an explicit line length.
+- `ruff check` and `ruff format --check` are both required in CI because the
+  formatter does not subsume linting.

--- a/docs/plans/ruff-migration/PLAN.md
+++ b/docs/plans/ruff-migration/PLAN.md
@@ -1,6 +1,6 @@
 # Ruff Migration
 
-Status: in_progress
+Status: done
 
 ## Goal
 
@@ -35,8 +35,8 @@ keeping the package runtime behavior and public API unchanged.
 - [x] Create the live feature plan and use it as the execution tracker.
 - [x] Replace Flake8 with Ruff in development dependencies and configuration.
 - [x] Update the local workflow and CI documentation to use Ruff.
-- [ ] Apply Ruff fixes, import sorting, and formatting to tracked Python files.
-- [ ] Validate Ruff, tests, and build commands from the migrated workflow.
+- [x] Apply Ruff fixes, import sorting, and formatting to tracked Python files.
+- [x] Validate Ruff, tests, and build commands from the migrated workflow.
 
 ## Notes / Findings
 
@@ -48,3 +48,8 @@ keeping the package runtime behavior and public API unchanged.
   formatter does not subsume linting.
 - The repo can rely on Ruff's default current-directory discovery, so the
   documented commands omit an explicit `.` path.
+- Ruff's first-party detection does not infer modules implemented only as
+  `.pyx` files, so `atomicl` needs an explicit `known-first-party` override to
+  keep `atomicl._cy` grouped with `atomicl._py`.
+- Final validation after the Ruff rewrite pass succeeded with `uv run ruff
+  check`, `uv run ruff format --check`, `uv run pytest`, and `uv build`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ benchmark = [
 [tool.ruff.lint]
 extend-select = ["I"]
 
+[tool.ruff.lint.isort]
+known-first-party = ["atomicl"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 timeout = 300

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dev = [
     "build>=1.2.2",
     "coverage>=7.8",
     "Cython>=3.1",
-    "flake8>=7.2",
     "pytest>=8.3",
     "pytest-timeout>=2.4",
+    "ruff>=0.15.9",
 ]
 test = [
     "coverage>=7.8",
@@ -50,6 +50,9 @@ benchmark = [
     "atomic",
     "pyperf",
 ]
+
+[tool.ruff.lint]
+extend-select = ["I"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,31 @@
-from setuptools import setup
-from setuptools import Extension
 from distutils.command.build_ext import build_ext
-from distutils.errors import CCompilerError
-from distutils.errors import DistutilsExecError
-from distutils.errors import DistutilsPlatformError
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+
+from setuptools import Extension, setup
 
 try:
     from Cython.Build import cythonize
+
     USE_CYTHON = True
 except ImportError:
     USE_CYTHON = False
 
 
-ext = '.pyx' if USE_CYTHON else '.c'
+ext = ".pyx" if USE_CYTHON else ".c"
 
 extensions = [
-    Extension('atomicl._cy', sources=[
-        'src/atomicl/_cy' + ext,
-        'src/atomicl/_atomic.c'
-    ], include_dirs=['src/atomicl/'])
+    Extension(
+        "atomicl._cy",
+        sources=["src/atomicl/_cy" + ext, "src/atomicl/_atomic.c"],
+        include_dirs=["src/atomicl/"],
+    )
 ]
 
 if USE_CYTHON:
     extensions = cythonize(
         extensions,
         annotate=True,
-        compiler_directives={'language_level': '3'},
+        compiler_directives={"language_level": "3"},
     )
 
 
@@ -43,8 +43,7 @@ class ve_build_ext(build_ext):
     def build_extension(self, ext):
         try:
             build_ext.build_extension(self, ext)
-        except (CCompilerError, DistutilsExecError,
-                DistutilsPlatformError, ValueError):
+        except (CCompilerError, DistutilsExecError, DistutilsPlatformError, ValueError):
             raise BuildFailed()
 
 
@@ -61,6 +60,6 @@ except BuildFailed:
     print("************************************************************")
     print("Cannot compile C accelerator module, use pure python version")
     print("************************************************************")
-    del args['ext_modules']
-    del args['cmdclass']
+    del args["ext_modules"]
+    del args["cmdclass"]
     setup(**args)

--- a/src/atomicl/__init__.py
+++ b/src/atomicl/__init__.py
@@ -4,4 +4,4 @@ except ImportError:
     from ._py import AtomicLong
 
 
-__all__ = ['AtomicLong']
+__all__ = ["AtomicLong"]

--- a/src/atomicl/_py.py
+++ b/src/atomicl/_py.py
@@ -2,8 +2,7 @@ import threading
 
 from atomicl import _structure
 
-
-__all__ = ['AtomicLong']
+__all__ = ["AtomicLong"]
 
 
 def raise_on_not_long(msg_format, val):
@@ -12,7 +11,7 @@ def raise_on_not_long(msg_format, val):
 
 
 class AtomicLong(_structure.AtomicLong):
-    __slots__ = ('_lock', '_value')
+    __slots__ = ("_lock", "_value")
 
     def __init__(self, initial_value=0):
         raise_on_not_long('initial value "%s" is not a long', initial_value)
@@ -71,5 +70,6 @@ class AtomicLong(_structure.AtomicLong):
             return current
 
     def __repr__(self):
-        return '<{0} at 0x{1}: {2!r}>'.format(
-            self.__class__.__name__, id(self), self._value)
+        return "<{0} at 0x{1}: {2!r}>".format(
+            self.__class__.__name__, id(self), self._value
+        )

--- a/tests/test_atomicl.py
+++ b/tests/test_atomicl.py
@@ -36,79 +36,66 @@ def test_public_api_uses_best_available_backend():
     assert atomicl.AtomicLong is _cy.AtomicLong
 
 
-@pytest.mark.parametrize('initial, expected', [
-    (_missing, 0),
-    (42, 42)
-])
+@pytest.mark.parametrize("initial, expected", [(_missing, 0), (42, 42)])
 def test_initial_default_value(impl, initial, expected):
     counter = impl() if initial is _missing else impl(initial)
     assert counter.value == expected
 
 
-@pytest.mark.parametrize('initial, val, expected', [
-    (0, 5, 5),
-    (5, 0, 0)
-])
+@pytest.mark.parametrize("initial, val, expected", [(0, 5, 5), (5, 0, 0)])
 def test_set(impl, initial, val, expected):
     counter = impl(initial)
     counter.value = val
     assert counter.value == expected
 
 
-@pytest.mark.parametrize('initial, val, expected', [
-    (0, 1, 1),
-    (0, 5, 5),
-    (40, 2, 42)
-])
+@pytest.mark.parametrize("initial, val, expected", [(0, 1, 1), (0, 5, 5), (40, 2, 42)])
 def test_add(impl, initial, val, expected):
     counter = impl(initial)
     counter += val
     assert counter.value == expected
 
 
-@pytest.mark.parametrize('initial, val, expected', [
-    (0, 1, -1),
-    (0, 5, -5),
-    (44, 2, 42)
-])
+@pytest.mark.parametrize(
+    "initial, val, expected", [(0, 1, -1), (0, 5, -5), (44, 2, 42)]
+)
 def test_sub(impl, initial, val, expected):
     counter = impl(initial)
     counter -= val
     assert counter.value == expected
 
 
-@pytest.mark.parametrize('initial, val', [
-    (0, 5),
-    (5, 0)
-])
+@pytest.mark.parametrize("initial, val", [(0, 5), (5, 0)])
 def test_get_and_set(impl, initial, val):
     counter = impl(initial)
     assert counter.get_and_set(val) == initial
     assert counter.value == val
 
 
-@pytest.mark.parametrize('initial, expected_value, val, success', [
-    (0, 0, 42, True),
-    (0, 42, 2, False)
-])
+@pytest.mark.parametrize(
+    "initial, expected_value, val, success", [(0, 0, 42, True), (0, 42, 2, False)]
+)
 def test_compare_and_set(impl, initial, expected_value, val, success):
     counter = impl(initial)
     assert counter.compare_and_set(expected_value, val) == success
     assert counter.value == (val if success else initial)
 
 
-@pytest.mark.parametrize('val', [0, 43])
+@pytest.mark.parametrize("val", [0, 43])
 def test_repr(impl, val):
-    pattern = re.compile(r'<AtomicLong at 0x\d+: %d>' % val)
+    pattern = re.compile(r"<AtomicLong at 0x\d+: %d>" % val)
     match = re.match(pattern, repr(impl(val)))
     assert bool(match) is True
 
 
-@pytest.mark.parametrize('val, msg', [
-    ('foo', 'new value "foo" is not a long'),
-    (1.5, 'new value "1.5" is not a long'),
-    ([], 'new value "[]" is not a long')
-])
+@pytest.mark.parametrize(
+    "val, msg",
+    [
+        ("foo", 'new value "foo" is not a long'),
+        (1.5, 'new value "1.5" is not a long'),
+        ([], 'new value "[]" is not a long'),
+    ],
+)
 def test_raises_if_new_value_is_not_a_long(impl, val, msg):
     counter = impl()
 
@@ -118,11 +105,14 @@ def test_raises_if_new_value_is_not_a_long(impl, val, msg):
     assert str(exc_info.value) == msg
 
 
-@pytest.mark.parametrize('val, msg', [
-    ('foo', 'initial value "foo" is not a long'),
-    (1.5, 'initial value "1.5" is not a long'),
-    ([], 'initial value "[]" is not a long')
-])
+@pytest.mark.parametrize(
+    "val, msg",
+    [
+        ("foo", 'initial value "foo" is not a long'),
+        (1.5, 'initial value "1.5" is not a long'),
+        ([], 'initial value "[]" is not a long'),
+    ],
+)
 def test_raises_if_initial_value_is_not_a_long(impl, val, msg):
     # raises#match behaves weirdly with []
     with pytest.raises(ValueError) as exc_info:
@@ -131,15 +121,15 @@ def test_raises_if_initial_value_is_not_a_long(impl, val, msg):
     assert str(exc_info.value) == msg
 
 
-@pytest.mark.parametrize('op', [
-    '__iadd__',
-    '__isub__'
-])
-@pytest.mark.parametrize('val, msg', [
-    (1.5, 'delta value "1.5" is not a long'),
-    ('foo', 'delta value "foo" is not a long'),
-    ([], 'delta value "[]" is not a long')
-])
+@pytest.mark.parametrize("op", ["__iadd__", "__isub__"])
+@pytest.mark.parametrize(
+    "val, msg",
+    [
+        (1.5, 'delta value "1.5" is not a long'),
+        ("foo", 'delta value "foo" is not a long'),
+        ([], 'delta value "[]" is not a long'),
+    ],
+)
 def test_raises_if_value_for_i_op_is_not_a_long(impl, op, val, msg):
     counter = impl()
     method = getattr(counter, op)
@@ -150,11 +140,14 @@ def test_raises_if_value_for_i_op_is_not_a_long(impl, op, val, msg):
     assert str(exc_info.value) == msg
 
 
-@pytest.mark.parametrize('val, msg', [
-    (1.5, 'new value "1.5" is not a long'),
-    ('foo', 'new value "foo" is not a long'),
-    ([], 'new value "[]" is not a long')
-])
+@pytest.mark.parametrize(
+    "val, msg",
+    [
+        (1.5, 'new value "1.5" is not a long'),
+        ("foo", 'new value "foo" is not a long'),
+        ([], 'new value "[]" is not a long'),
+    ],
+)
 def test_raises_if_value_for_get_and_set_is_not_a_long(impl, val, msg):
     counter = impl()
 
@@ -164,11 +157,14 @@ def test_raises_if_value_for_get_and_set_is_not_a_long(impl, val, msg):
     assert str(exc_info.value) == msg
 
 
-@pytest.mark.parametrize('val, msg', [
-    (1.5, 'expected value "1.5" is not a long'),
-    ('foo', 'expected value "foo" is not a long'),
-    ([], 'expected value "[]" is not a long')
-])
+@pytest.mark.parametrize(
+    "val, msg",
+    [
+        (1.5, 'expected value "1.5" is not a long'),
+        ("foo", 'expected value "foo" is not a long'),
+        ([], 'expected value "[]" is not a long'),
+    ],
+)
 def test_raises_if_expected_value_for_cas_is_not_a_long(impl, val, msg):
     counter = impl()
 
@@ -178,11 +174,14 @@ def test_raises_if_expected_value_for_cas_is_not_a_long(impl, val, msg):
     assert str(exc_info.value) == msg
 
 
-@pytest.mark.parametrize('val, msg', [
-    (1.5, 'new value "1.5" is not a long'),
-    ('foo', 'new value "foo" is not a long'),
-    ([], 'new value "[]" is not a long')
-])
+@pytest.mark.parametrize(
+    "val, msg",
+    [
+        (1.5, 'new value "1.5" is not a long'),
+        ("foo", 'new value "foo" is not a long'),
+        ([], 'new value "[]" is not a long'),
+    ],
+)
 def test_raises_if_new_value_for_cas_if_not_a_long(impl, val, msg):
     counter = impl()
 
@@ -192,10 +191,10 @@ def test_raises_if_new_value_for_cas_if_not_a_long(impl, val, msg):
     assert str(exc_info.value) == msg
 
 
-@pytest.mark.parametrize('op, loops, val, expected', [
-    ('__iadd__', 10 ** 5, 1, 200000),
-    ('__isub__', 10 ** 5, 1, -200000)
-])
+@pytest.mark.parametrize(
+    "op, loops, val, expected",
+    [("__iadd__", 10**5, 1, 200000), ("__isub__", 10**5, 1, -200000)],
+)
 def test_concurrently(impl, op, loops, val, expected):
     def worker():
         method = getattr(counter, op)
@@ -206,7 +205,7 @@ def test_concurrently(impl, op, loops, val, expected):
             method(val)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
-        for _ in range(2 ** 5):
+        for _ in range(2**5):
             counter = impl()
             event = threading.Event()
 

--- a/uv.lock
+++ b/uv.lock
@@ -25,9 +25,9 @@ dev = [
     { name = "build" },
     { name = "coverage" },
     { name = "cython" },
-    { name = "flake8" },
     { name = "pytest" },
     { name = "pytest-timeout" },
+    { name = "ruff" },
 ]
 test = [
     { name = "coverage" },
@@ -46,9 +46,9 @@ dev = [
     { name = "build", specifier = ">=1.2.2" },
     { name = "coverage", specifier = ">=7.8" },
     { name = "cython", specifier = ">=3.1" },
-    { name = "flake8", specifier = ">=7.2" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-timeout", specifier = ">=2.4" },
+    { name = "ruff", specifier = ">=0.15.9" },
 ]
 test = [
     { name = "coverage", specifier = ">=7.8" },
@@ -283,35 +283,12 @@ wheels = [
 ]
 
 [[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -361,30 +338,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -443,4 +402,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]


### PR DESCRIPTION
## Why

The repository still uses Flake8 for linting even though the rest of the local and CI workflow already relies on Astral tooling via `uv`. Moving to Ruff consolidates linting, formatting, and import sorting under one tool while keeping the runtime package behavior unchanged.

## What Changed

- added a live `docs/plans/ruff-migration/PLAN.md` tracker for the migration
- replaced the `flake8` development dependency with `ruff` and updated the lockfile
- configured Ruff with its default rule set plus import sorting via the `I` rule family
- updated the README developer workflow to use `uv run ruff check`, `uv run ruff check --fix`, and `uv run ruff format`
- changed GitHub Actions lint validation to run both `uv run ruff check` and `uv run ruff format --check`
- applied Ruff-driven import sorting and formatting to the tracked Python files in scope

## Impact

Developers now use Ruff instead of Flake8 for repository linting, formatting, and import sorting. CI also fails on formatting drift in addition to lint violations, so the documented local commands and GitHub validation match.

## Validation

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pytest`
- `uv build`
