### PR TITLE
Drop automatic extension build fallback

### DIFF
--- a/docs/plans/extension-build-hint/PLAN.md
+++ b/docs/plans/extension-build-hint/PLAN.md
@@ -1,6 +1,6 @@
 # Extension Build Hint
 
-Status: proposed
+Status: done
 
 ## Goal
 
@@ -27,13 +27,19 @@ successfully or fail, and pure-Python installs only happen when
 
 ## Tasks
 
-- [ ] Create the live feature plan and use it as the execution tracker.
-- [ ] Remove the automatic pure-Python fallback from `setup.py`.
-- [ ] Add an actionable install hint for failed accelerated builds.
-- [ ] Run the existing project checks against the updated packaging behavior.
+- [x] Create the live feature plan and use it as the execution tracker.
+- [x] Remove the automatic pure-Python fallback from `setup.py`.
+- [x] Add an actionable install hint for failed accelerated builds.
+- [x] Run the existing project checks against the updated packaging behavior.
 
 ## Notes / Findings
 
 - No dedicated packaging/integration test module exists in the repository, so
   this work is expected to rely on the existing project validation commands plus
   targeted manual packaging-path checks if needed.
+- The default build path now stays accelerated-only: extension failures bubble
+  out as a hard error with an explicit `ATOMICL_NO_EXTENSIONS=1` hint instead of
+  retrying `setup()` in pure-Python mode.
+- A targeted `/tmp` packaging check with an intentionally broken `_atomic.c`
+  confirmed the new hard failure message and the explicit
+  `ATOMICL_NO_EXTENSIONS=1` pure-Python path.

--- a/docs/plans/extension-build-hint/PLAN.md
+++ b/docs/plans/extension-build-hint/PLAN.md
@@ -1,0 +1,39 @@
+# Extension Build Hint
+
+Status: proposed
+
+## Goal
+
+Keep packaging on a single build path: accelerated installs either compile
+successfully or fail, and pure-Python installs only happen when
+`ATOMICL_NO_EXTENSIONS` is set explicitly.
+
+## Exit Criteria
+
+- Default installs attempt the native extension once and do not fall back to a
+  second `setup()` invocation.
+- A failed accelerated build exits with a clear hint to set
+  `ATOMICL_NO_EXTENSIONS=1` for a pure-Python install.
+- Setting `ATOMICL_NO_EXTENSIONS=1` still produces the explicit pure-Python
+  install path.
+
+## Context
+
+- `origin/master` still retries `setup()` after a failed extension build.
+- Editable installs can fail when setuptools re-enters the build pipeline after
+  that first failure.
+- The requested behavior is to drop the automatic fallback instead of retrying
+  the build in a different mode.
+
+## Tasks
+
+- [ ] Create the live feature plan and use it as the execution tracker.
+- [ ] Remove the automatic pure-Python fallback from `setup.py`.
+- [ ] Add an actionable install hint for failed accelerated builds.
+- [ ] Run the existing project checks against the updated packaging behavior.
+
+## Notes / Findings
+
+- No dedicated packaging/integration test module exists in the repository, so
+  this work is expected to rely on the existing project validation commands plus
+  targeted manual packaging-path checks if needed.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,13 @@ extensions = [
 ]
 
 
-class BuildFailed(BaseException):
+BUILD_FAILURE_HINT = (
+    "Failed to build the optional native extension. "
+    "Set ATOMICL_NO_EXTENSIONS=1 to force a pure-Python install."
+)
+
+
+class BuildFailed(Exception):
     pass
 
 
@@ -30,14 +36,19 @@ class ve_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except (DistutilsPlatformError, FileNotFoundError):
-            raise BuildFailed()
+        except (DistutilsPlatformError, FileNotFoundError) as exc:
+            raise BuildFailed(BUILD_FAILURE_HINT) from exc
 
     def build_extension(self, ext):
         try:
             build_ext.build_extension(self, ext)
-        except (CCompilerError, DistutilsExecError, DistutilsPlatformError, ValueError):
-            raise BuildFailed()
+        except (
+            CCompilerError,
+            DistutilsExecError,
+            DistutilsPlatformError,
+            ValueError,
+        ) as exc:
+            raise BuildFailed(BUILD_FAILURE_HINT) from exc
 
 
 NO_EXTENSIONS = bool(os.environ.get("ATOMICL_NO_EXTENSIONS"))
@@ -53,13 +64,7 @@ if not NO_EXTENSIONS:
     print("*********************")
     print("* Accelerated build *")
     print("*********************")
-    try:
-        setup(ext_modules=extensions, cmdclass=dict(build_ext=ve_build_ext))
-    except BuildFailed:
-        print("*********************")
-        print("* Pure Python build *")
-        print("*********************")
-        setup()
+    setup(ext_modules=extensions, cmdclass=dict(build_ext=ve_build_ext))
 else:
     print("*********************")
     print("* Pure Python build *")


### PR DESCRIPTION
## Why

Default installs currently try the accelerated build first and then re-enter `setup()` to retry as a pure-Python build when extension compilation fails. That retry path is unsafe for editable installs because setuptools has already entered the build pipeline by the time the second `setup()` call happens.

This change keeps packaging on a single build path. The accelerated path now either compiles successfully or fails, and users who want the pure-Python install must opt into it explicitly with `ATOMICL_NO_EXTENSIONS=1`.

## What Changed

- remove the automatic pure-Python fallback from `setup.py`
- raise a clear build failure with an `ATOMICL_NO_EXTENSIONS=1` hint when the native extension cannot be compiled
- keep the explicit pure-Python path unchanged when `ATOMICL_NO_EXTENSIONS` is set
- update the live plan for this bugfix and record the targeted packaging-path check that exercised both outcomes