### PR TITLE
Switch native atomics to stdatomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Install dependencies (Windows)
-        if: runner.os == 'Windows'
-        env:
-          ATOMICL_NO_EXTENSIONS: "1"
-        run: uv sync
-
-      - name: Install dependencies (POSIX)
-        if: runner.os != 'Windows'
+      - name: Install dependencies
         run: uv sync
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 - added `ATOMICL_NO_EXTENSIONS=1` as an opt-out for compiling the optional native extension
 - migrated the native atomic implementation from compiler-specific `__atomic_*` builtins to C11 `<stdatomic.h>`
 - updated native extension build flags to request C11 atomics for both POSIX toolchains and MSVC
+- updated Windows CI to build and test the native extension path instead of forcing the pure-Python fallback
 
 ### Fixed
 - preserved optional native-extension fallback behavior across Cython, generated C, and pure-Python paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
 - removed `tox` from the local workflow
 - migrated CI from Travis CI to GitHub Actions
 - added `ATOMICL_NO_EXTENSIONS=1` as an opt-out for compiling the optional native extension
+- migrated the native atomic implementation from compiler-specific `__atomic_*` builtins to C11 `<stdatomic.h>`
+- updated native extension build flags to request C11 atomics for both POSIX toolchains and MSVC
 
 ### Fixed
 - preserved optional native-extension fallback behavior across Cython, generated C, and pure-Python paths

--- a/docs/plans/stdatomic-migration/PLAN.md
+++ b/docs/plans/stdatomic-migration/PLAN.md
@@ -1,6 +1,6 @@
 # C11 Stdatomic Migration
 
-Status: in_progress
+Status: done
 
 ## Goal
 
@@ -36,7 +36,7 @@ with MSVC's experimental C11 atomics support.
 - [x] Update build configuration to request C11 mode, including the Windows
   experiment flags.
 - [x] Validate lint/tests locally on the current toolchain.
-- [ ] Update CI to build and test the native extension on Windows.
+- [x] Update CI to build and test the native extension on Windows.
 
 ## Notes / Findings
 
@@ -56,5 +56,5 @@ with MSVC's experimental C11 atomics support.
 - Build flag selection needs to follow the active compiler, not just the OS:
   MSVC needs `/std:c11` together with `/experimental:c11atomics`, while
   Unix-style compilers use `-std=c11`.
-- Local validation passed with the corrected Windows flag selection; CI
-  revalidation is pending on the current PR head.
+- GitHub Actions validates native Windows extension builds successfully on the
+  current PR head for `windows-latest` with Python 3.11, 3.12, 3.13, and 3.14.

--- a/docs/plans/stdatomic-migration/PLAN.md
+++ b/docs/plans/stdatomic-migration/PLAN.md
@@ -1,0 +1,48 @@
+# C11 Stdatomic Migration
+
+Status: in_progress
+
+## Goal
+
+Switch the native atomic implementation from compiler-specific GCC/Clang
+extensions to the C11 `<stdatomic.h>` API, while preserving the current
+runtime behavior and testing whether Windows CI can build the native extension
+with MSVC's experimental C11 atomics support.
+
+## Exit Criteria
+
+- The native implementation uses C11 atomics instead of `__atomic_*` builtins.
+- Local tests still pass on the current development toolchain.
+- The build configuration requests C11 mode where needed for the native code.
+- Windows CI is updated to attempt the native extension build with MSVC's
+  experimental C11 atomics support instead of forcing pure Python.
+- The plan records whether the Windows CI experiment succeeded or failed.
+
+## Context
+
+- The current C layer in `src/atomicl/_atomic.c` uses GCC-compatible
+  `__atomic_*` builtins with sequentially consistent ordering.
+- The current GitHub Actions workflow disables native extension builds on
+  Windows by setting `ATOMICL_NO_EXTENSIONS=1`.
+- Current Microsoft documentation still describes C-mode `<stdatomic.h>`
+  support as experimental, but Visual Studio has a preview-only
+  `/experimental:c11atomics` path that is worth trying in CI.
+
+## Tasks
+
+- [x] Create the live feature plan and use it as the execution tracker.
+- [ ] Migrate the C implementation to `<stdatomic.h>` with equivalent
+  sequentially consistent semantics.
+- [ ] Update build configuration to request C11 mode, including the Windows
+  experiment flags.
+- [ ] Validate lint/tests locally on the current toolchain.
+- [ ] Update CI to attempt the native extension build on Windows and record the
+  result.
+
+## Notes / Findings
+
+- Windows CI already runs across supported Python versions, so the native build
+  experiment can be isolated to workflow configuration rather than adding a new
+  job family.
+- The native API only needs fetch-add, fetch-sub, exchange, and compare-exchange,
+  all of which have direct C11 `<stdatomic.h>` equivalents.

--- a/docs/plans/stdatomic-migration/PLAN.md
+++ b/docs/plans/stdatomic-migration/PLAN.md
@@ -31,13 +31,12 @@ with MSVC's experimental C11 atomics support.
 ## Tasks
 
 - [x] Create the live feature plan and use it as the execution tracker.
-- [ ] Migrate the C implementation to `<stdatomic.h>` with equivalent
+- [x] Migrate the C implementation to `<stdatomic.h>` with equivalent
   sequentially consistent semantics.
-- [ ] Update build configuration to request C11 mode, including the Windows
+- [x] Update build configuration to request C11 mode, including the Windows
   experiment flags.
-- [ ] Validate lint/tests locally on the current toolchain.
-- [ ] Update CI to attempt the native extension build on Windows and record the
-  result.
+- [x] Validate lint/tests locally on the current toolchain.
+- [ ] Update CI to build and test the native extension on Windows.
 
 ## Notes / Findings
 
@@ -46,3 +45,16 @@ with MSVC's experimental C11 atomics support.
   job family.
 - The native API only needs fetch-add, fetch-sub, exchange, and compare-exchange,
   all of which have direct C11 `<stdatomic.h>` equivalents.
+- `uv sync` showed that Cython 3.2.4 does not compile cleanly when an extension
+  attribute itself is declared as `_Atomic long long`; its generated Python-int
+  conversion helpers still treat the type as an arithmetic scalar.
+- The safe migration path is to keep `_Atomic long long` hidden inside a C
+  wrapper struct, so Cython holds a plain opaque native struct while the helper
+  layer owns the actual atomic field and operations.
+- Local validation passed with `uv sync`, `uv run ruff check`, and
+  `uv run pytest -q`.
+- Build flag selection needs to follow the active compiler, not just the OS:
+  MSVC needs `/std:c11` together with `/experimental:c11atomics`, while
+  Unix-style compilers use `-std=c11`.
+- Local validation passed with the corrected Windows flag selection; CI
+  revalidation is pending on the current PR head.

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,26 @@ BUILD_FAILURE_HINT = (
     "Set ATOMICL_NO_EXTENSIONS=1 to force a pure-Python install."
 )
 
+C11_UNIX_FLAGS = ["-std=c11"]
+C11_MSVC_FLAGS = ["/std:c11", "/experimental:c11atomics"]
+
 
 class BuildFailed(Exception):
     pass
 
 
 class ve_build_ext(build_ext):
+    def build_extensions(self):
+        if self.compiler.compiler_type == "msvc":
+            cflags = C11_MSVC_FLAGS
+        else:
+            cflags = C11_UNIX_FLAGS
+
+        for ext in self.extensions:
+            ext.extra_compile_args = list(cflags)
+
+        build_ext.build_extensions(self)
+
     def run(self):
         try:
             build_ext.run(self)

--- a/src/atomicl/_atomic.c
+++ b/src/atomicl/_atomic.c
@@ -1,15 +1,29 @@
-long long get_and_add(long long* ptr, long long val) {
-    return __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
+#include "_atomic.h"
+
+void init_atomic_long_long(atomic_long_long* ptr, long long val) {
+    atomic_init(&ptr->value, val);
 }
 
-long long get_and_sub(long long* ptr, long long val) {
-    return __atomic_fetch_sub(ptr, val, __ATOMIC_SEQ_CST);
+long long load_value(atomic_long_long* ptr) {
+    return atomic_load(&ptr->value);
 }
 
-long long get_and_set(long long* ptr, long long val) {
-    return __atomic_exchange_n(ptr, val, __ATOMIC_SEQ_CST);
+void store_value(atomic_long_long* ptr, long long val) {
+    atomic_store(&ptr->value, val);
 }
 
-int compare_and_set(long long* ptr, long long exp, long long val) {
-    return __atomic_compare_exchange_n(ptr, &exp, val, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+long long get_and_add(atomic_long_long* ptr, long long val) {
+    return atomic_fetch_add(&ptr->value, val);
+}
+
+long long get_and_sub(atomic_long_long* ptr, long long val) {
+    return atomic_fetch_sub(&ptr->value, val);
+}
+
+long long get_and_set(atomic_long_long* ptr, long long val) {
+    return atomic_exchange(&ptr->value, val);
+}
+
+int compare_and_set(atomic_long_long* ptr, long long exp, long long val) {
+    return atomic_compare_exchange_strong(&ptr->value, &exp, val);
 }

--- a/src/atomicl/_atomic.h
+++ b/src/atomicl/_atomic.h
@@ -1,9 +1,19 @@
 #ifndef ATOMICL__ATOMIC_H_
 #define ATOMICL__ATOMIC_H_
 
-long long get_and_add(long long *ptr, long long val);
-long long get_and_sub(long long *ptr, long long val);
-long long get_and_set(long long *ptr, long long val);
-int compare_and_set(long long *ptr, long long exp, long long val);
+#include <stdatomic.h>
+
+typedef struct atomic_long_long {
+    _Atomic long long value;
+} atomic_long_long;
+
+void init_atomic_long_long(atomic_long_long *ptr, long long val);
+long long load_value(atomic_long_long *ptr);
+void store_value(atomic_long_long *ptr, long long val);
+
+long long get_and_add(atomic_long_long *ptr, long long val);
+long long get_and_sub(atomic_long_long *ptr, long long val);
+long long get_and_set(atomic_long_long *ptr, long long val);
+int compare_and_set(atomic_long_long *ptr, long long exp, long long val);
 
 #endif  // ATOMICL__ATOMIC_H_

--- a/src/atomicl/_catomic.pxd
+++ b/src/atomicl/_catomic.pxd
@@ -1,5 +1,12 @@
 cdef extern from '_atomic.h' nogil:
-    long long get_and_add(long long *ptr, long long val)
-    long long get_and_sub(long long *ptr, long long val)
-    long long get_and_set(long long *ptr, long long val)
-    bint compare_and_set(long long *ptr, long long exp, long long val)
+    ctypedef struct atomic_long_long:
+        pass
+
+    void init_atomic_long_long(atomic_long_long *ptr, long long val)
+    long long load_value(atomic_long_long *ptr)
+    void store_value(atomic_long_long *ptr, long long val)
+
+    long long get_and_add(atomic_long_long *ptr, long long val)
+    long long get_and_sub(atomic_long_long *ptr, long long val)
+    long long get_and_set(atomic_long_long *ptr, long long val)
+    bint compare_and_set(atomic_long_long *ptr, long long exp, long long val)

--- a/src/atomicl/_cy.pyx
+++ b/src/atomicl/_cy.pyx
@@ -11,22 +11,22 @@ cdef raise_on_not_long(msg_format, val):
 
 
 cdef class AtomicLong:
-    cdef long long _value
+    cdef atomic.atomic_long_long _value
 
     def __init__(self, initial_value=0):
         raise_on_not_long('initial value "%s" is not a long', initial_value)
 
-        self._value = initial_value
+        atomic.init_atomic_long_long(&self._value, initial_value)
 
     @property
     def value(self):
-        return self._value
+        return atomic.load_value(&self._value)
 
     @value.setter
     def value(self, new_value):
         raise_on_not_long('new value "%s" is not a long', new_value)
 
-        self._value = new_value
+        atomic.store_value(&self._value, new_value)
 
     def __iadd__(self, other):
         raise_on_not_long('delta value "%s" is not a long', other)
@@ -55,7 +55,7 @@ cdef class AtomicLong:
 
     def __repr__(self):
         return '<{0} at 0x{1}: {2!r}>'.format(
-            self.__class__.__name__, id(self), self._value)
+            self.__class__.__name__, id(self), atomic.load_value(&self._value))
 
 
 _structure.AtomicLong.register(AtomicLong)


### PR DESCRIPTION
## Why

The native extension currently relies on GCC/Clang `__atomic_*` builtins. That works on Unix-like toolchains, but it keeps the implementation tied to compiler-specific syntax and leaves Windows support outside the native-extension path.

This change migrates the implementation to the C11 `<stdatomic.h>` API and updates CI so Windows builds and tests the native extension instead of forcing the pure-Python path.

## What Changed

- replaced the native atomic operations in `src/atomicl/_atomic.c` with C11 `<stdatomic.h>` calls
- hid `_Atomic long long` inside a native wrapper struct so Cython can store the atomic state inline without generating invalid scalar conversions
- updated the Cython declarations and wrapper class to use that inline native atomic storage while preserving the existing `AtomicLong` ABC surface
- changed `setup.py` to select compiler-appropriate C11 flags at build time, including `/std:c11` and `/experimental:c11atomics` for MSVC
- removed the Windows CI override that previously set `ATOMICL_NO_EXTENSIONS=1`
- updated the live plan and changelog to record the implementation, compiler-flag follow-up, and validated Windows outcome

## Impact

Linux, macOS, and Windows now validate the native extension path in CI on Python 3.11, 3.12, 3.13, and 3.14. The implementation uses standard C11 atomics instead of GCC-specific intrinsics, and Windows no longer needs to fall back to the pure-Python install path in CI.

The build now selects flags from the active compiler: Unix-style compilers use `-std=c11`, while MSVC uses `/std:c11` together with `/experimental:c11atomics`, matching Microsoft's C11 atomics announcement for Visual Studio 2022 17.5 Preview 2 ([C11 Atomics in Visual Studio 2022 version 17.5 Preview 2](https://devblogs.microsoft.com/cppblog/c11-atomics-in-visual-studio-2022-version-17-5-preview-2/)).