### PR TITLE
Clarify AGENTS.md precedence and PR guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+Follow any applicable system-level instructions and user-level instructions
+(for example, a user-level `AGENTS.md`) first. Within the repository, follow
+the most specific instructions that apply; treat this file as the default
+repository-wide guidance unless a more specific repository-local file says
+otherwise.
+
 ## Planning
 
 Repository-specific plan guidance lives in [docs/plans/README.md](docs/plans/README.md).
@@ -17,3 +23,11 @@ Repository-specific plan guidance lives in [docs/plans/README.md](docs/plans/REA
 ## Working On Code
 
 - Do not include machine-specific absolute filesystem paths in checked-in files; prefer repository-relative paths and links when applicable.
+- Keep `CHANGELOG.md` updated for public-facing changes such as supported Python version updates, new APIs, breaking changes, packaging changes, and behavior fixes; do not add internal-only implementation or process details. Follow the project's existing changelog structure and use https://keepachangelog.com/en/1.0.0/ as a guide.
+
+## PRs
+
+- Keep the PR title and body updated so they reflect the latest state of the branch before submission.
+- Before submitting a PR, run two independent sub-agent reviews in rigorous review mode.
+- Those review agents should have no context other than the PR title, PR body, and the actual changed files.
+- Instruct both reviewers to challenge assumptions, verify backward compatibility, and confirm they agree with the PR description and the code as written.


### PR DESCRIPTION
## Why

The repository instructions already define planning and code-change expectations, but they do not clearly state how repo-local guidance composes with broader instructions, when `CHANGELOG.md` should be updated, or what quality bar applies before a PR is submitted.

This change tightens `AGENTS.md` so contributors have explicit guidance for instruction precedence, changelog maintenance, and PR preparation.

## What Changed

- added a precedence note at the top of `AGENTS.md` clarifying that system-level and user-level instructions apply first, and that the most specific repository-local instructions win within the repository
- documented that `CHANGELOG.md` is for public-facing changes such as supported Python version updates, new APIs, breaking changes, packaging changes, and behavior fixes, not internal-only implementation or process details, and pointed contributors to follow the project’s changelog structure with Keep a Changelog as a guide
- added a `PRs` section requiring the PR title and body to stay aligned with the latest branch state
- required two independent sub-agent reviews before PR submission, scoped to the PR title, PR body, and changed files, with explicit checks for challenged assumptions, backward compatibility, and agreement between description and implementation

## Impact

Contributors get clearer repository-specific instructions for instruction precedence, maintaining the changelog for public-facing release notes, and preparing PRs, and the repo now documents a stricter pre-submission review expectation.