### PR TITLE
Clean up README and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,11 @@ Changelog
 ## [Unreleased]
 
 ### Changed
-- modernized packaging and development workflow to `pyproject.toml` and `uv`
 - updated supported CPython versions to `3.11` through `3.14`
-- removed `tox` from the local workflow
-- migrated CI from Travis CI to GitHub Actions
 - added `ATOMICL_NO_EXTENSIONS=1` as an opt-out for compiling the optional native extension
 - migrated the native atomic implementation from compiler-specific `__atomic_*` builtins to C11 `<stdatomic.h>`
 - updated native extension build flags to request C11 atomics for both POSIX toolchains and MSVC
-- updated Windows CI to build and test the native extension path instead of forcing the pure-Python fallback
-
-### Fixed
-- preserved optional native-extension fallback behavior across Cython, generated C, and pure-Python paths
+- dropped automatic fallback from native-extension build failures to the pure-Python install path; use `ATOMICL_NO_EXTENSIONS=1` to force a pure-Python install
 
 ## [0.1.1] - 2018-11-13
 ## Added

--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,8 @@ Build Behavior
 --------------
 
 The package keeps an optional Cython-backed extension for the fast path
-and retains the pure Python fallback for environments where the native
-extension cannot be compiled.
+and retains a pure Python implementation for environments where the
+native extension is not installed.
 
 Building the native extension requires a working C compiler toolchain.
 
@@ -121,8 +121,8 @@ When ``ATOMICL_NO_EXTENSIONS=1`` is set, packaging skips configuring the
 extension and installs the pure Python implementation directly.
 
 When Cython is not available, the build falls back to ``src/atomicl/_cy.c``.
-If the extension build fails, installation falls back to the pure Python
-implementation.
+If the extension build fails, installation fails; set
+``ATOMICL_NO_EXTENSIONS=1`` to force a pure Python install.
 
 Differences from atomic_
 ------------------------


### PR DESCRIPTION
## Why

Recent packaging changes dropped the automatic fallback from native-extension build failures to the pure-Python install path, but the README and unreleased changelog still described that fallback as if it were current behavior.

The unreleased changelog also still included internal process notes that do not belong in public-facing release notes.

This PR cleans up the README and changelog so they reflect the current behavior and focus on user-visible changes.

## What Changed

- updated the README build-behavior section to distinguish the runtime pure-Python implementation from packaging-time extension build behavior
- clarified that missing Cython still falls back to generated C, but native-extension build failures now fail the install unless `ATOMICL_NO_EXTENSIONS=1` is set
- removed internal/process-only unreleased changelog entries and replaced the stale fallback note with the current explicit pure-Python install guidance

## Impact

The README and changelog now match the current packaging contract and stay focused on public-facing behavior. Users reading the install guidance should no longer expect an automatic pure-Python install after an extension build failure.